### PR TITLE
Handle posix_memalign errors

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -75,7 +75,9 @@ void* std_aligned_alloc(size_t alignment, size_t size) {
     return aligned_alloc(alignment, size);
 #elif defined(POSIXALIGNEDALLOC)
     void* mem = nullptr;
-    posix_memalign(&mem, alignment, size);
+    int err = posix_memalign(&mem, alignment, size);
+    if (err != 0)
+        return nullptr;
     return mem;
 #elif defined(_WIN32) && !defined(_M_ARM) && !defined(_M_ARM64)
     return _mm_malloc(size, alignment);


### PR DESCRIPTION
## Summary
- handle `posix_memalign` failure by returning `nullptr` from `std_aligned_alloc`

## Testing
- `cd src && make build`

------
https://chatgpt.com/codex/tasks/task_e_68a90184690c8327910bd2b809ad94c3