### PR TITLE
Rename Wordfish to Revolution and update licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Revolution Chess Engine
+
+Copyright (c) 2024 Jorge Ruiz Centelles
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Revolution incorporates code from the Stockfish, Berserk, and Obsidian chess
+engines, each distributed under the terms of the GNU General Public License
+version 3.  As such, this distribution is also released under the GPL v3.
+
+You should have received a copy of the GNU General Public License along with
+this program in the file Copying.txt. If not, see <https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
-# Wordfish Chess Engine
+# Revolution Chess Engine
 
 <div align="center">
-  <img src="[https://ijccrl.com/wp-content/uploads/2025/08/wordfish.png]" 
-  <h3>Wordfish</h3>
+  <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 
+  <h3>Revolution</h3>
   
   A free and open-source UCI chess engine combining classical algorithms with neural network innovations.
   <br>
-  <strong><a href="#">Explore Wordfish Documentation »</a>
+  <strong><a href="#">Explore Revolution Documentation »</a>
+
+  <em>Author: Jorge Ruiz Centelles</em>
   
 </div>
 
 ## Overview
 
-**Wordfish** is a free, open-source UCI chess engine implementing cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Wordfish analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
+**Revolution** is a free, open-source UCI chess engine implementing cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Revolution analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
 
-As a UCI-compliant engine, Wordfish operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
+As a UCI-compliant engine, Revolution operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
 
 ## Technical Architecture
 
-Wordfish's architecture features:
+Revolution's architecture features:
 
 - Hybrid evaluation system combining classical heuristics with NNUE networks
 - SMP parallelization with YBWC (Young Brothers Wait Concept)
@@ -34,7 +36,7 @@ The distribution includes:
 - `COPYING.txt` ([GNU GPL v3 license][gpl-link])
 - `AUTHORS` (contributor acknowledgments)
 - `src/` (source code with platform-specific Makefiles)
-- Neural network weights (`wordfish.nnue`)
+- Neural network weights (`revolution.nnue`)
 
 ## Contributing
 
@@ -47,13 +49,13 @@ Contributions must adhere to:
 
 ### Testing Infrastructure
 Improvements require extensive testing:
-- Install the [Wordfish Test Worker][worker-link]
-- Participate in active tests on [Wordfish Test Suite][testsuite-link]
+- Install the [Revolution Test Worker][worker-link]
+- Participate in active tests on [Revolution Test Suite][testsuite-link]
 - Verify ELO gains through SPRT validation
 
 ### Community
 Technical discussions occur primarily through:
-- [Wordfish Discord Server][discord-link]
+- [Revolution Discord Server][discord-link]
 - [GitHub Discussions][discussions-link]
 - [Chess Programming Wiki][chesswiki-link]
 
@@ -74,7 +76,7 @@ Full compilation guides available in [documentation][doc-link].
 
 ## License
 
-Wordfish is licensed under the **[GNU General Public License v3][gpl-link]** (GPL v3). This grants permission to:
+Revolution is licensed under the **[GNU General Public License v3][gpl-link]** (GPL v3). This grants permission to:
 - Use, modify, and distribute the software
 - Incorporate into larger projects
 - Conduct commercial utilization
@@ -86,7 +88,7 @@ Wordfish is licensed under the **[GNU General Public License v3][gpl-link]** (GP
 
 ## Acknowledgements
 
-Wordfish incorporates:
+Revolution incorporates:
 - Neural networks trained on [Lichess open database][lichess-db]
 - Search techniques from [CCC testing community][ccc-link]
 - Positional analysis concepts from [CPW research][cpw-link]
@@ -103,7 +105,7 @@ Wordfish incorporates:
 [ccc-link]: https://www.chess.com/computer-chess-championship
 [cpw-link]: https://www.chessprogramming.org
 
-# Changes into Wordfish 1.0 dev 120825
+# Changes into Revolution 1.0 dev 120825
 Changes made:
 
 The definition of the CommandLine class in misc.cpp has been removed (lines 37-40 of the original content).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     // Clear, consistent banner (many GUIs echo this to their logs)
     std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE
               << ' ' << __DATE__ << ' ' << __TIME__
-              << " by Jorge Ruiz" << std::endl;
+              << " by Jorge Ruiz Centelles" << std::endl;
 
     std::cout << compiler_info() << std::endl;
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -123,7 +123,7 @@ std::string engine_version_info() {
 
 // Update author information
 std::string engine_info(bool to_uci) {
-    return engine_version_info() + (to_uci ? "\nid author " : " by ") + "Jorge Ruiz";
+    return engine_version_info() + (to_uci ? "\nid author " : " by ") + "Jorge Ruiz Centelles";
 }
 
 // Returns a string trying to describe the compiler we use

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -116,7 +116,7 @@ void UCIEngine::loop() {
         {
             // Force a stable, explicit UCI name so GUIs show "Wordfish 1.0.1 dev <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
-                << "id author Jorge Ruiz" << "\n"
+                << "id author Jorge Ruiz Centelles" << "\n"
                 << engine.get_options() << sync_endl;
 
             sync_cout << "uciok" << sync_endl;

--- a/src/uci_handshake_name.patch
+++ b/src/uci_handshake_name.patch
@@ -31,7 +31,7 @@ index 0000000..0000001 100644
 -                      << engine.get_options() << sync_endl;
 +            // Force a stable, explicit UCI name so GUIs show "Wordfish 1.0.1 dev <date>"
 +            sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
-+                      << "id author Jorge Ruiz" << "\n"
++                      << "id author Jorge Ruiz Centelles" << "\n"
 +                      << engine.get_options() << sync_endl;
  
              sync_cout << "uciok" << sync_endl;

--- a/src/uci_idname.patch
+++ b/src/uci_idname.patch
@@ -36,7 +36,7 @@ diff --git a/src/uci.cpp b/src/uci.cpp
 +//     while (std::cin >> token) {
 +//         if (token == "uci") {
 +//             uci_print_id_name();
-+//             std::cout << "id author Jorge Ruiz" << std::endl;
++//             std::cout << "id author Jorge Ruiz Centelles" << std::endl;
 +//             // ... print options, then:
 +//             std::cout << "uciok" << std::endl;
 +//         }


### PR DESCRIPTION
## Summary
- Rename documentation references from Wordfish to Revolution.
- Credit Jorge Ruiz Centelles in source headers and metadata.
- Add a GPLv3 license with attribution to Stockfish, Berserk, and Obsidian.

## Testing
- `python3 -m py_compile tests/testing.py`
- `python3 -m py_compile tests/instrumented.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa55c83cd0832786e8f2a5ed9170d4