### PR TITLE
Clarify GPLv3 references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -9,7 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 
 Revolution incorporates code from the Stockfish, Berserk, and Obsidian chess
 engines, each distributed under the terms of the GNU General Public License
-version 3.  As such, this distribution is also released under the GPL v3.
+version 3 (GPLv3). As such, this distribution is also released under GPLv3.
 
 You should have received a copy of the GNU General Public License along with
 this program in the file Copying.txt. If not, see <https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Revolution's architecture features:
 The distribution includes:
 
 - `README.md` (this documentation)
-- `COPYING.txt` ([GNU GPL v3 license][gpl-link])
+- `COPYING.txt` ([GNU GPLv3 license][gpl-link])
 - `AUTHORS` (contributor acknowledgments)
 - `src/` (source code with platform-specific Makefiles)
 - Neural network weights (`revolution.nnue`)


### PR DESCRIPTION
## Summary
- Clarify GPLv3 wording in the LICENSE to emphasize inherited licenses from Stockfish, Berserk, and Obsidian.
- Update README to refer to the GNU GPLv3 license file.

## Testing
- `make build -j2 ARCH=x86-64-sse41-popcnt` *(failed: uci.o: file format not recognized)*
- `./tests/signature.sh` *(failed: ./stockfish: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa597621808327beeb152db614d811