### PR TITLE
Handle Syzygy premap option changes

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -123,7 +123,11 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
-    options.add("SyzygyPremap", Option(false));
+    options.add(
+      "SyzygyPremap", Option(false, [this](const Option& o) {
+          Tablebases::init(options["SyzygyPath"], bool(o));
+          return std::nullopt;
+      }));
     options.add("SyzygyProbeDepth", Option(1, 1, 100));
 
     options.add("Syzygy50MoveRule", Option(true));


### PR DESCRIPTION
## Summary
- Reinitialize tablebases when `SyzygyPremap` option changes

## Testing
- `make build ARCH=x86-64-sse41-popcnt`
- `./revolution bench`


------
https://chatgpt.com/codex/tasks/task_e_68aa755f4dd8832791fcbcc70e496c6c