### PR TITLE
Add experience file option

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -120,6 +120,9 @@ class Engine {
     TranspositionTable                       tt;
     LazyNumaReplicated<Eval::NNUE::Networks> networks;
 
+    std::string experienceFile;
+    bool        experienceFileCreated = false;
+
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;
 };


### PR DESCRIPTION
## Summary
- support storing search experience by adding `Experience` and `Experience File` UCI options
- create the experience file automatically in the engine directory on first analysis

## Testing
- `make build`
- `./tests/perft.sh` *(fails: `exit code: 127`)*


------
https://chatgpt.com/codex/tasks/task_e_68aa96ff3ac0832796537d5b9d5682a6