### PR TITLE
Silence unused width parameter

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -32,7 +32,8 @@ void Experience::save(const std::string& file) const {
                 << '\n';
 }
 
-Move Experience::probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves) {
+Move Experience::probe(Position& pos, [[maybe_unused]] int width,
+                       int evalImportance, int minDepth, int maxMoves) {
     auto it = table.find(pos.key());
     if (it == table.end())
         return Move::none();

--- a/src/experience.h
+++ b/src/experience.h
@@ -22,7 +22,8 @@ class Experience {
     void clear();
     void load(const std::string& file);
     void save(const std::string& file) const;
-    Move probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves);
+    Move probe(Position& pos, [[maybe_unused]] int width, int evalImportance,
+               int minDepth, int maxMoves);
     void update(Position& pos, Move move, int score, int depth);
 
    private:


### PR DESCRIPTION
## Summary
- mark width parameter in Experience::probe as `[[maybe_unused]]`
- propagate attribute to declaration in experience.h

## Testing
- `make build ARCH=x86-64-sse41-popcnt -j2`

------
https://chatgpt.com/codex/tasks/task_e_68aa9fae9ca48327a5909314f0b5f162