### PR TITLE
Silence unused width parameter and rename experience file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ expense of additional startup time and memory usage.
 
 ## Experience Book
 
-Revolution puede aprender de partidas previas guardando datos en un archivo `.exp`.
+Revolution puede aprender de partidas previas guardando datos en un archivo `.bin`.
 Las siguientes opciones UCI controlan este sistema:
 
 - `Experience Enabled`: activa o desactiva la experiencia (por defecto `true`).
-- `Experience File`: nombre del archivo donde se almacena la experiencia (por defecto `raptora.exp`).
+- `Experience File`: nombre del archivo donde se almacena la experiencia (por defecto `revolution.bin`).
 - `Experience Readonly`: si es `true`, no se escriben cambios en el archivo.
 - `Experience Book`: usa la experiencia como libro de aperturas.
 - `Experience Book Width`: número de movimientos principales a considerar (1–20).

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,4 +1,4 @@
 Revolution 1.0 dev 120825
 - Initial fork from Stockfish with ideas from Berserk and Obsidian.
 - Updated engine name and build system.
-- Added experience book system with persistent `.exp` file and new UCI options.
+- Added experience book system with persistent `.bin` file and new UCI options.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -168,7 +168,7 @@ Engine::Engine(std::optional<std::string> path) :
                     return std::nullopt;
                 }));
 
-    options.add("Experience File", Option("raptora.exp", [this](const Option& o) {
+    options.add("Experience File", Option("revolution.bin", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load(o);
                     return std::nullopt;

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -32,7 +32,8 @@ void Experience::save(const std::string& file) const {
                 << '\n';
 }
 
-Move Experience::probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves) {
+Move Experience::probe(Position& pos, [[maybe_unused]] int width,
+                       int evalImportance, int minDepth, int maxMoves) {
     auto it = table.find(pos.key());
     if (it == table.end())
         return Move::none();

--- a/src/experience.h
+++ b/src/experience.h
@@ -22,7 +22,8 @@ class Experience {
     void clear();
     void load(const std::string& file);
     void save(const std::string& file) const;
-    Move probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves);
+    Move probe(Position& pos, [[maybe_unused]] int width, int evalImportance,
+               int minDepth, int maxMoves);
     void update(Position& pos, Move move, int score, int depth);
 
    private:


### PR DESCRIPTION
## Summary
- mark width parameter in `Experience::probe` as `[[maybe_unused]]`
- rename default experience file to `revolution.bin` and update docs

## Testing
- `make build ARCH=x86-64-sse41-popcnt -j2`


------
https://chatgpt.com/codex/tasks/task_e_68aa9fae9ca48327a5909314f0b5f162