### PR TITLE
Reduce LMR for checking moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1054,6 +1054,12 @@ moves_loop:  // When in check, search starts here
 
         Depth r = reduction(improving, depth, moveCount, delta);
 
+        // Don't over-reduce moves that give check. Checking moves often have
+        // high tactical significance, so we allow them slightly more search
+        // depth by decreasing the late move reduction.
+        if (givesCheck)
+            r = std::max<Depth>(0, r - 512);
+
         // Increase reduction for ttPv nodes (*Scaler)
         // Smaller or even negative value is better for short time controls
         // Bigger value is better for long time controls


### PR DESCRIPTION
## Summary
- Avoid over-reducing checking moves during late-move reductions to preserve tactical lines.

## Testing
- `make build ARCH=x86-64-sse41-popcnt -j2`
- `tests/perft.sh` *(fails: `expect` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac596079a883278c8a960dbe15ef7f