### PR TITLE
Rename engine to Wordfish 1.0.1 dev with build date

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -842,11 +842,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Revolution 1.0 dev"
+#   - ENGINE_NAME: "Wordfish 1.0.1 dev"
 #   - ENGINE_BUILD_DATE: system date in yymmdd format
 # You can override on the command line:
-#   make ENGINE_NAME="Revolution 1.0.2 beta" ENGINE_BUILD_DATE=251001
-ENGINE_NAME        ?= Revolution 1.0 dev
+#   make ENGINE_NAME="Wordfish 1.0.1 beta" ENGINE_BUILD_DATE=251001
+ENGINE_NAME        ?= Wordfish 1.0.1 dev
 ENGINE_BUILD_DATE  ?= $(shell date +%y%m%d)
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,4 +1,4 @@
-Revolution 1.0 dev 120825
+Wordfish 1.0.1 dev
 - Initial fork from Stockfish with ideas from Berserk and Obsidian.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file and new UCI options.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  Revolution, a UCI chess engine based on Stockfish, Berserk, and Obsidian
+  Wordfish, a UCI chess engine based on Stockfish, Berserk, and Obsidian
   Copyright (C) 2024 Jorge Ruiz Centelles
 
   This program is free software: you can redistribute it and/or modify
@@ -18,13 +18,13 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-// yymmdd; override at build time with:  -DENGINE_BUILD_DATE=250822
-#define ENGINE_BUILD_DATE "120825"
+// Fallback to compilation date if not provided by the build system
+#define ENGINE_BUILD_DATE __DATE__
 #endif
 
 #ifndef ENGINE_NAME
-// override at build time with:  -DENGINE_NAME="\"Revolution 1.0 dev\""
-#define ENGINE_NAME "Revolution 1.0 dev"
+// Override at build time with:  -DENGINE_NAME="\"Wordfish 1.0.1 dev\""
+#define ENGINE_NAME "Wordfish 1.0.1 dev"
 #endif
 
 using namespace Stockfish;
@@ -32,8 +32,7 @@ using namespace Stockfish;
 int main(int argc, char* argv[]) {
 
     // Clear, consistent banner (many GUIs echo this to their logs)
-    std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE
-              << ' ' << __DATE__ << ' ' << __TIME__
+    std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << ' ' << __TIME__
               << " by Jorge Ruiz Centelles" << std::endl;
 
     std::cout << compiler_info() << std::endl;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,5 +1,5 @@
 /*
-  Revolution, a UCI chess engine based on Stockfish, Berserk, and Obsidian
+  Wordfish, a UCI chess engine based on Stockfish, Berserk, and Obsidian
   Copyright (C) 2024 Jorge Ruiz Centelles
 
   This program is free software: you can redistribute it and/or modify
@@ -30,7 +30,7 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "120825"
+#define ENGINE_BUILD_DATE __DATE__
 #endif
 
 namespace Stockfish {
@@ -111,9 +111,9 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Revolution version.
+// Returns the full name of the current Wordfish version.
 std::string engine_version_info() {
-    return std::string("Revolution 1.0 ") + version.data();
+    return std::string("Wordfish 1.0.1 dev ") + version.data();
 }
 
 // Update author information

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -114,7 +114,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 1.0 dev <date>"
+            // Force a stable, explicit UCI name so GUIs show "Wordfish 1.0.1 dev <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
                 << "id author Jorge Ruiz Centelles" << "\n"
                 << engine.get_options() << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -1,5 +1,5 @@
 /*
-  Revolution, a UCI chess engine based on Stockfish, Berserk, and Obsidian
+  Wordfish, a UCI chess engine based on Stockfish, Berserk, and Obsidian
   Copyright (C) 2024 Jorge Ruiz Centelles
 
   This program is free software: you can redistribute it and/or modify
@@ -13,10 +13,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Revolution 1.0 dev"
+#define ENGINE_NAME "Wordfish 1.0.1 dev"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "120825"  // yymmdd; overridden by Makefile if provided
+#define ENGINE_BUILD_DATE __DATE__  // overridden by Makefile if provided
 #endif
 
 


### PR DESCRIPTION
## Summary
- Rename engine defaults to **Wordfish 1.0.1 dev**
- Include build date in version info and UCI responses
- Update Makefile defaults and changelog accordingly

## Testing
- `make clean`
- `make build` *(passes)*
- `tests/perft.sh` *(fails: `expect` not found, exit code 127)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5beb36348327856b17589aa0c39f