### PR TITLE
Rename executable and update engine metadata

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution.exe
+EXE = wordfish.exe
 else
-        EXE = revolution
+EXE = wordfish
 endif
 
 ### Installation dir definitions

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -168,7 +168,7 @@ Engine::Engine(std::optional<std::string> path) :
                     return std::nullopt;
                 }));
 
-    options.add("Experience File", Option("revolution.exp", [this](const Option& o) {
+    options.add("Experience File", Option("wordfish.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load(o);
                     return std::nullopt;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -32,6 +32,9 @@
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE __DATE__
 #endif
+#ifndef ENGINE_NAME
+#define ENGINE_NAME "Wordfish 1.0.1 dev"
+#endif
 
 namespace Stockfish {
 
@@ -113,7 +116,7 @@ class Logger {
 
 // Returns the full name of the current Wordfish version.
 std::string engine_version_info() {
-    return std::string("Wordfish 1.0.1 dev ") + version.data();
+    return std::string(ENGINE_NAME) + " " + version.data();
 }
 
 // Update author information


### PR DESCRIPTION
## Summary
- rename generated binary to `wordfish`
- default experience file renamed to `wordfish.exp`
- derive version info from `ENGINE_NAME` with a sensible default

## Testing
- `make build ARCH=x86-64-sse41-popcnt COMP=gcc -j2`
- `./wordfish`

------
https://chatgpt.com/codex/tasks/task_e_68ac60766b988327a1635020a47429c7